### PR TITLE
replace NAT GW with TGW

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ module "aft_account_request_framework" {
   aft_vpc_private_subnet_02_cidr              = var.aft_vpc_private_subnet_02_cidr
   aft_vpc_public_subnet_01_cidr               = var.aft_vpc_public_subnet_01_cidr
   aft_vpc_public_subnet_02_cidr               = var.aft_vpc_public_subnet_02_cidr
+  aft_tgw_cidrs                               = var.aft_tgw_cidrs
   concurrent_account_factory_actions          = var.concurrent_account_factory_actions
   request_framework_archive_path              = module.packaging.request_framework_archive_path
   request_framework_archive_hash              = module.packaging.request_framework_archive_hash

--- a/modules/aft-account-request-framework/variables.tf
+++ b/modules/aft-account-request-framework/variables.tf
@@ -37,6 +37,10 @@ variable "aft_vpc_public_subnet_02_cidr" {
   type = string
 }
 
+variable "aft_tgw_cidrs" {
+  type = list(string)
+}
+
 variable "request_framework_archive_path" {
   type = string
 }

--- a/modules/aft-account-request-framework/vpc.tf
+++ b/modules/aft-account-request-framework/vpc.tf
@@ -44,10 +44,72 @@ module "aft-vpc-subnets" {
     public  = [var.aft_vpc_public_subnet_01_cidr, var.aft_vpc_public_subnet_02_cidr]
   }]
 
-  nat_gateway_enabled     = true
+  nat_gateway_enabled     = false
   public_subnets_enabled  = true
   map_public_ip_on_launch = false
 
   public_open_network_acl_enabled  = false
   private_open_network_acl_enabled = false
+}
+
+data "aws_ec2_transit_gateway" "tgw" {
+  filter {
+    name   = "options.amazon-side-asn"
+    values = ["64512"]
+  }
+}
+
+module "tg-attachment" {
+  source = "cloudposse/transit-gateway/aws"
+
+  version = "0.11.0"
+
+  existing_transit_gateway_id = data.aws_ec2_transit_gateway.tgw.id
+
+  create_transit_gateway                                         = false
+  create_transit_gateway_route_table                             = false
+  create_transit_gateway_vpc_attachment                          = true
+  create_transit_gateway_route_table_association_and_propagation = false
+
+  config = {
+    aft = {
+      vpc_id   = module.aft-vpc.vpc_id
+      vpc_cidr = module.aft-vpc.vpc_cidr_block
+
+      subnet_ids             = module.aft-vpc-subnets.private_subnet_ids
+      subnet_route_table_ids = module.aft-vpc-subnets.private_route_table_ids
+
+      route_to                          = null
+      route_to_cidr_blocks              = var.aft_tgw_cidrs
+      static_routes                     = []
+      transit_gateway_vpc_attachment_id = null
+    }
+  }
+}
+
+module "vpc-endpoints" {
+  source  = "cloudposse/vpc/aws//modules/vpc-endpoints"
+  version = ">= 2.1.0"
+
+  vpc_id = module.aft-vpc.vpc_id
+
+  gateway_vpc_endpoints = {
+    "s3" = {
+      name = "s3"
+      policy = jsonencode({
+        Version = "2012-10-17"
+        Statement = [
+          {
+            Action = [
+              "s3:*",
+            ]
+            Effect    = "Allow"
+            Principal = "*"
+            Resource  = "*"
+          },
+        ]
+      })
+      route_table_ids = module.aft-vpc-subnets.private_route_table_ids
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -364,6 +364,12 @@ variable "aft_vpc_public_subnet_02_cidr" {
   }
 }
 
+variable "aft_tgw_cidrs" {
+  type        = list(string)
+  description = "CIDR Block to route to via Transit Gateway"
+  default     = ["0.0.0.0/0"]
+}
+
 #########################################
 # AFT Metrics Reporting Variables
 #########################################


### PR DESCRIPTION
- add S3 gateway endpoint
- use MTG as the default gateway instead of NAT GWs

```
  # module.aft_pipeline.module.aft_account_request_framework.module.aft-vpc-subnets.aws_eip.default[0] will be destroyed
  # (because index [0] is out of range for count)
  - resource "aws_eip" "default" {
      - allocation_id        = "eipalloc-0aa451feb837bdc6c" -> null
      - association_id       = "eipassoc-068fac88f6ebc470c" -> null
      - domain               = "vpc" -> null
      - id                   = "eipalloc-0aa451feb837bdc6c" -> null
      - network_border_group = "eu-central-1" -> null
      - network_interface    = "eni-096a28dec6dc484bf" -> null
      - private_dns          = "ip-192-168-2-89.eu-central-1.compute.internal" -> null
      - private_ip           = "192.168.2.89" -> null
      - public_dns           = "ec2-18-196-9-10.eu-central-1.compute.amazonaws.com" -> null
      - public_ip            = "18.196.9.10" -> null
      - public_ipv4_pool     = "amazon" -> null
      - tags                 = {
          - "Attributes" = "nat"
          - "Name"       = "aft-vpc-nat-euc1a"
        } -> null
      - tags_all             = {
          - "Attributes" = "nat"
          - "Name"       = "aft-vpc-nat-euc1a"
          - "managed_by" = "AFT"
        } -> null
      - vpc                  = true -> null
    }

  # module.aft_pipeline.module.aft_account_request_framework.module.aft-vpc-subnets.aws_eip.default[1] will be destroyed
  # (because index [1] is out of range for count)
  - resource "aws_eip" "default" {
      - allocation_id        = "eipalloc-05b4ae126c06caf4e" -> null
      - association_id       = "eipassoc-0d364c7884948acd1" -> null
      - domain               = "vpc" -> null
      - id                   = "eipalloc-05b4ae126c06caf4e" -> null
      - network_border_group = "eu-central-1" -> null
      - network_interface    = "eni-01971b798d42603cf" -> null
      - private_dns          = "ip-192-168-2-134.eu-central-1.compute.internal" -> null
      - private_ip           = "192.168.2.134" -> null
      - public_dns           = "ec2-35-156-216-238.eu-central-1.compute.amazonaws.com" -> null
      - public_ip            = "35.156.216.238" -> null
      - public_ipv4_pool     = "amazon" -> null
      - tags                 = {
          - "Attributes" = "nat"
          - "Name"       = "aft-vpc-nat-euc1b"
        } -> null
      - tags_all             = {
          - "Attributes" = "nat"
          - "Name"       = "aft-vpc-nat-euc1b"
          - "managed_by" = "AFT"
        } -> null
      - vpc                  = true -> null
    }

  # module.aft_pipeline.module.aft_account_request_framework.module.aft-vpc-subnets.aws_nat_gateway.default[0] will be destroyed
  # (because index [0] is out of range for count)
  - resource "aws_nat_gateway" "default" {
      - allocation_id                      = "eipalloc-0aa451feb837bdc6c" -> null
      - association_id                     = "eipassoc-068fac88f6ebc470c" -> null
      - connectivity_type                  = "public" -> null
      - id                                 = "nat-0f209a202b3257b24" -> null
      - network_interface_id               = "eni-096a28dec6dc484bf" -> null
      - private_ip                         = "192.168.2.89" -> null
      - public_ip                          = "18.196.9.10" -> null
      - secondary_allocation_ids           = [] -> null
      - secondary_private_ip_address_count = 0 -> null
      - secondary_private_ip_addresses     = [] -> null
      - subnet_id                          = "subnet-0c7bf9baf7146928f" -> null
      - tags                               = {
          - "Attributes" = "nat"
          - "Name"       = "aft-vpc-nat-euc1a"
        } -> null
      - tags_all                           = {
          - "Attributes" = "nat"
          - "Name"       = "aft-vpc-nat-euc1a"
          - "managed_by" = "AFT"
        } -> null
    }

  # module.aft_pipeline.module.aft_account_request_framework.module.aft-vpc-subnets.aws_nat_gateway.default[1] will be destroyed
  # (because index [1] is out of range for count)
  - resource "aws_nat_gateway" "default" {
      - allocation_id                      = "eipalloc-05b4ae126c06caf4e" -> null
      - association_id                     = "eipassoc-0d364c7884948acd1" -> null
      - connectivity_type                  = "public" -> null
      - id                                 = "nat-0e649cf9fa73dc307" -> null
      - network_interface_id               = "eni-01971b798d42603cf" -> null
      - private_ip                         = "192.168.2.134" -> null
      - public_ip                          = "35.156.216.238" -> null
      - secondary_allocation_ids           = [] -> null
      - secondary_private_ip_address_count = 0 -> null
      - secondary_private_ip_addresses     = [] -> null
      - subnet_id                          = "subnet-070d093f006ffd98f" -> null
      - tags                               = {
          - "Attributes" = "nat"
          - "Name"       = "aft-vpc-nat-euc1b"
        } -> null
      - tags_all                           = {
          - "Attributes" = "nat"
          - "Name"       = "aft-vpc-nat-euc1b"
          - "managed_by" = "AFT"
        } -> null
    }

  # module.aft_pipeline.module.aft_account_request_framework.module.aft-vpc-subnets.aws_route.nat4[0] will be destroyed
  # (because index [0] is out of range for count)
  - resource "aws_route" "nat4" {
      - destination_cidr_block = "0.0.0.0/0" -> null
      - id                     = "r-rtb-0bb613a8faac2c6a91080289494" -> null
      - nat_gateway_id         = "nat-0f209a202b3257b24" -> null
      - origin                 = "CreateRoute" -> null
      - route_table_id         = "rtb-0bb613a8faac2c6a9" -> null
      - state                  = "active" -> null
    }

  # module.aft_pipeline.module.aft_account_request_framework.module.aft-vpc-subnets.aws_route.nat4[1] will be destroyed
  # (because index [1] is out of range for count)
  - resource "aws_route" "nat4" {
      - destination_cidr_block = "0.0.0.0/0" -> null
      - id                     = "r-rtb-0fe2cc200d7b76bb81080289494" -> null
      - nat_gateway_id         = "nat-0e649cf9fa73dc307" -> null
      - origin                 = "CreateRoute" -> null
      - route_table_id         = "rtb-0fe2cc200d7b76bb8" -> null
      - state                  = "active" -> null
    }

  # module.aft_pipeline.module.aft_account_request_framework.module.tg-attachment.aws_ec2_transit_gateway_vpc_attachment.default["aft"] will be created
  + resource "aws_ec2_transit_gateway_vpc_attachment" "default" {
      + appliance_mode_support                          = "disable"
      + dns_support                                     = "enable"
      + id                                              = (known after apply)
      + ipv6_support                                    = "disable"
      + subnet_ids                                      = [
          + "subnet-00ff86a48d0d1053b",
          + "subnet-0cb0a14749611c33c",
        ]
      + tags_all                                        = {
          + "managed_by" = "AFT"
        }
      + transit_gateway_default_route_table_association = (known after apply)
      + transit_gateway_default_route_table_propagation = (known after apply)
      + transit_gateway_id                              = "tgw-01bac6d8a63cb8adc"
      + vpc_id                                          = "vpc-0dd44776a133f05d5"
      + vpc_owner_id                                    = (known after apply)
    }

  # module.aft_pipeline.module.aft_account_request_framework.module.vpc-endpoints.data.aws_vpc_endpoint.gateway["s3"] will be read during apply
  # (config refers to values not yet known)
 <= data "aws_vpc_endpoint" "gateway" {
      + arn                   = (known after apply)
      + cidr_blocks           = (known after apply)
      + dns_entry             = (known after apply)
      + dns_options           = (known after apply)
      + id                    = (known after apply)
      + ip_address_type       = (known after apply)
      + network_interface_ids = (known after apply)
      + owner_id              = (known after apply)
      + policy                = (known after apply)
      + prefix_list_id        = (known after apply)
      + private_dns_enabled   = (known after apply)
      + requester_managed     = (known after apply)
      + route_table_ids       = (known after apply)
      + security_group_ids    = (known after apply)
      + service_name          = (known after apply)
      + state                 = (known after apply)
      + subnet_ids            = (known after apply)
      + tags                  = (known after apply)
      + vpc_endpoint_type     = (known after apply)
      + vpc_id                = (known after apply)
    }

  # module.aft_pipeline.module.aft_account_request_framework.module.vpc-endpoints.aws_vpc_endpoint.gateway_endpoint["s3"] will be created
  + resource "aws_vpc_endpoint" "gateway_endpoint" {
      + arn                   = (known after apply)
      + cidr_blocks           = (known after apply)
      + dns_entry             = (known after apply)
      + id                    = (known after apply)
      + ip_address_type       = (known after apply)
      + network_interface_ids = (known after apply)
      + owner_id              = (known after apply)
      + policy                = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = [
                          + "s3:*",
                        ]
                      + Effect    = "Allow"
                      + Principal = "*"
                      + Resource  = "*"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + prefix_list_id        = (known after apply)
      + private_dns_enabled   = false
      + requester_managed     = (known after apply)
      + route_table_ids       = (known after apply)
      + security_group_ids    = (known after apply)
      + service_name          = "com.amazonaws.eu-central-1.s3"
      + state                 = (known after apply)
      + subnet_ids            = (known after apply)
      + tags                  = {
          + "Attributes" = "s3"
          + "Name"       = "s3"
        }
      + tags_all              = {
          + "Attributes" = "s3"
          + "Name"       = "s3"
          + "managed_by" = "AFT"
        }
      + vpc_endpoint_type     = "Gateway"
      + vpc_id                = "vpc-0dd44776a133f05d5"
    }

  # module.aft_pipeline.module.aft_account_request_framework.module.vpc-endpoints.aws_vpc_endpoint_route_table_association.gateway["s3[0]"] will be created
  + resource "aws_vpc_endpoint_route_table_association" "gateway" {
      + id              = (known after apply)
      + route_table_id  = "rtb-0bb613a8faac2c6a9"
      + vpc_endpoint_id = (known after apply)
    }

  # module.aft_pipeline.module.aft_account_request_framework.module.vpc-endpoints.aws_vpc_endpoint_route_table_association.gateway["s3[1]"] will be created
  + resource "aws_vpc_endpoint_route_table_association" "gateway" {
      + id              = (known after apply)
      + route_table_id  = "rtb-0fe2cc200d7b76bb8"
      + vpc_endpoint_id = (known after apply)
    }

  # module.aft_pipeline.module.aft_account_request_framework.module.vpc-endpoints.time_sleep.creation[0] will be created
  + resource "time_sleep" "creation" {
      + create_duration = "30s"
      + id              = (known after apply)
    }

  # module.aft_pipeline.module.aft_account_request_framework.module.tg-attachment.module.subnet_route["aft"].aws_route.count[0] will be created
  + resource "aws_route" "count" {
      + destination_cidr_block = "0.0.0.0/0"
      + id                     = (known after apply)
      + instance_id            = (known after apply)
      + instance_owner_id      = (known after apply)
      + network_interface_id   = (known after apply)
      + origin                 = (known after apply)
      + route_table_id         = "rtb-0bb613a8faac2c6a9"
      + state                  = (known after apply)
      + transit_gateway_id     = "tgw-01bac6d8a63cb8adc"

      + timeouts {
          + create = "5m"
        }
    }

  # module.aft_pipeline.module.aft_account_request_framework.module.tg-attachment.module.subnet_route["aft"].aws_route.count[1] will be created
  + resource "aws_route" "count" {
      + destination_cidr_block = "0.0.0.0/0"
      + id                     = (known after apply)
      + instance_id            = (known after apply)
      + instance_owner_id      = (known after apply)
      + network_interface_id   = (known after apply)
      + origin                 = (known after apply)
      + route_table_id         = "rtb-0fe2cc200d7b76bb8"
      + state                  = (known after apply)
      + transit_gateway_id     = "tgw-01bac6d8a63cb8adc"

      + timeouts {
          + create = "5m"
        }
    }

```